### PR TITLE
Show accept dialog when discarding changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,10 @@ an easy and efficient tool.
 
 ## TODO
 
-- alert user that new rubric or open rubric discards any changes
-- support enter key in save dialog 
 - create example rubrics
-- after adding move focus to added field
+- after adding files move focus to added field
 - add documentation
+- aria tags for accessibility
 
 ## Developing and building Rubric
 

--- a/client/src/AcceptDialog.tsx
+++ b/client/src/AcceptDialog.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Icon,
+} from '@material-ui/core'
+import { TFunction } from 'i18next'
+
+interface Props {
+  open: boolean
+  title: string
+  message: string
+  cancelButtonKey: string
+  acceptButtonKey: string
+  closeDialogOnCancel: () => void
+  closeDialogOnAccept: () => void
+  t: TFunction
+}
+
+const AcceptDialog = (props: Props): JSX.Element => {
+  const t = props.t
+
+  return (
+    <Dialog
+      open={props.open}
+      onClose={props.closeDialogOnCancel}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+    >
+      <DialogTitle id="alert-dialog-title">
+        <Icon fontSize="small">error</Icon> {props.title}
+      </DialogTitle>
+      <DialogContent>
+        <div style={{ fontSize: 'large' }}>{props.message}</div>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={props.closeDialogOnCancel} color="inherit" autoFocus>
+          {t(props.cancelButtonKey)}
+        </Button>
+        <Button
+          type="submit"
+          onClick={props.closeDialogOnAccept}
+          color="primary"
+          autoFocus
+        >
+          {t(props.acceptButtonKey)}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default AcceptDialog

--- a/client/src/DownloadDialog.tsx
+++ b/client/src/DownloadDialog.tsx
@@ -15,8 +15,8 @@ import { SectionType } from './types'
 interface Props {
   open: boolean
   sections: SectionType[]
-  closeDialogAfterCancel: () => void
-  closeDialogAfterSave: () => void
+  closeDialogOnCancel: () => void
+  closeDialogOnSave: () => void
   t: TFunction
 }
 
@@ -46,7 +46,7 @@ const DownloadDialog = (props: Props): JSX.Element => {
         </Grid>
       </DialogContent>
       <DialogActions>
-        <Button onClick={props.closeDialogAfterCancel}>{t('cancel')}</Button>
+        <Button onClick={props.closeDialogOnCancel}>{t('cancel')}</Button>
         <Button
           color="primary"
           component={Link}
@@ -55,7 +55,7 @@ const DownloadDialog = (props: Props): JSX.Element => {
             encodeURIComponent(JSON.stringify(props.sections, null, 2))
           }
           download={filename + extension}
-          onClick={props.closeDialogAfterSave}
+          onClick={props.closeDialogOnSave}
         >
           {t('save')}
         </Button>

--- a/client/src/MainMenu.tsx
+++ b/client/src/MainMenu.tsx
@@ -17,6 +17,7 @@ import Ajv from 'ajv'
 import rubricSchema from './rubricSchema.json'
 import AlertDialog, { AlertDialogStateType } from './AlertDialog'
 import DownloadDialog from './DownloadDialog'
+import AcceptDialog from './AcceptDialog'
 
 const ajv = new Ajv()
 
@@ -47,6 +48,8 @@ const MainMenu = (props: Props): JSX.Element => {
   const [alertDialogState, setAlertDialogState] = useState(closedAlertDialog)
   const [snackbarOpen, setSnackbarOpen] = useState(false)
   const [downloadDialogOpen, setDownloadDialogOpen] = useState(false)
+  const [acceptNewDialogOpen, setAcceptNewDialogOpen] = useState(false)
+  const [acceptOpenDialogOpen, setAcceptOpenDialogOpen] = useState(false)
 
   const t = props.t
   const uploaderRefObject = useRef() as MutableRefObject<HTMLInputElement>
@@ -107,6 +110,7 @@ const MainMenu = (props: Props): JSX.Element => {
       reader.readAsText(file)
     }
   }
+  const createNewRubric = () => props.setSectionsAndCleanAppState([])
 
   return (
     <Grid container spacing={4} alignItems="center">
@@ -152,8 +156,12 @@ const MainMenu = (props: Props): JSX.Element => {
 
           <MenuItem
             onClick={() => {
+              if (props.appState.dirty) {
+                setAcceptNewDialogOpen(true)
+              } else {
+                createNewRubric()
+              }
               setAnchorEl(null)
-              props.setSectionsAndCleanAppState([])
             }}
           >
             <ListItemIcon>
@@ -162,21 +170,19 @@ const MainMenu = (props: Props): JSX.Element => {
             <ListItemText>{t('newRubric')}</ListItemText>
           </MenuItem>
 
-          <MenuItem onClick={() => uploaderRefObject.current.click()}>
+          <MenuItem
+            onClick={() => {
+              if (props.appState.dirty) {
+                setAcceptOpenDialogOpen(true)
+              } else {
+                uploaderRefObject.current.click()
+              }
+            }}
+          >
             <ListItemIcon>
               <Icon>open_in_browser</Icon>
             </ListItemIcon>
-            <ListItemText>
-              <input
-                type="file"
-                accept="text/json"
-                multiple={false}
-                ref={uploaderRefObject}
-                style={{ display: 'none' }}
-                onChange={uploadRubric}
-              />
-              {t('openRubric')}
-            </ListItemText>
+            <ListItemText>{t('openRubric')}</ListItemText>
           </MenuItem>
 
           <MenuItem onClick={() => setDownloadDialogOpen(true)}>
@@ -213,11 +219,11 @@ const MainMenu = (props: Props): JSX.Element => {
         <DownloadDialog
           open={downloadDialogOpen}
           sections={props.appState.sections}
-          closeDialogAfterCancel={() => {
+          closeDialogOnCancel={() => {
             setDownloadDialogOpen(false)
             setAnchorEl(null)
           }}
-          closeDialogAfterSave={() => {
+          closeDialogOnSave={() => {
             setDownloadDialogOpen(false)
             setAnchorEl(null)
             props.cleanAppState()
@@ -228,6 +234,51 @@ const MainMenu = (props: Props): JSX.Element => {
           dialogState={alertDialogState}
           closeDialog={closeAlertDialog}
           t={t}
+        />
+        <AcceptDialog
+          open={acceptNewDialogOpen}
+          title={t('discardChanges')}
+          message={t('discardUnsavedChangesAndCreateNew')}
+          cancelButtonKey="cancel"
+          acceptButtonKey="discardAndCreateNew"
+          closeDialogOnCancel={() => {
+            setAcceptNewDialogOpen(false)
+            setAnchorEl(null)
+          }}
+          closeDialogOnAccept={() => {
+            setAcceptNewDialogOpen(false)
+            setAnchorEl(null)
+            createNewRubric()
+          }}
+          t={t}
+        />
+        <AcceptDialog
+          open={acceptOpenDialogOpen}
+          title={t('discardChanges')}
+          message={t('discardUnsavedChangesAndOpen')}
+          cancelButtonKey="cancel"
+          acceptButtonKey="discardAndOpen"
+          closeDialogOnCancel={() => {
+            setAcceptOpenDialogOpen(false)
+            setAnchorEl(null)
+          }}
+          closeDialogOnAccept={() => {
+            setAcceptOpenDialogOpen(false)
+            setAnchorEl(null)
+            uploaderRefObject.current.click()
+          }}
+          t={t}
+        />
+        <input
+          type="file"
+          accept="text/json,.json"
+          multiple={false}
+          ref={uploaderRefObject}
+          style={{ display: 'none' }}
+          onChange={uploadRubric}
+          onClick={(event: React.MouseEvent<HTMLInputElement>) =>
+            (event.currentTarget.value = '')
+          }
         />
         <Snackbar
           anchorOrigin={{

--- a/client/src/translations/en.json
+++ b/client/src/translations/en.json
@@ -1,6 +1,11 @@
 {
   "menu": "Menu",
   "saveChanges": "Save changes...",
+  "discardChanges": "Discard changes?",
+  "discardUnsavedChangesAndCreateNew": "Discard unsaved changes and create new rubric?",
+  "discardUnsavedChangesAndOpen": "Discard unsaved changes and open rubric?",
+  "discardAndCreateNew": "Discard and create new",
+  "discardAndOpen": "Discard and open",
   "section": "Section",
   "addSection": "Add section",
   "selectAndCopy": "Select and Copy",

--- a/client/src/translations/fi.json
+++ b/client/src/translations/fi.json
@@ -1,6 +1,11 @@
 {
   "menu": "Valikko",
   "saveChanges": "Tallenna muutokset...",
+  "discardChanges": "Hylkää muutokset?",
+  "discardUnsavedChangesAndCreateNew": "Hylkää tallentamattomat muutokset ja luo uusi rubriikki?",
+  "discardUnsavedChangesAndOpen": "Hylkää tallentamattomat muutokset ja avaa rubriikki?",
+  "discardAndCreateNew": "Hylkää ja luo uusi",
+  "discardAndOpen": "Hylkää ja avaa",
   "section": "Osio",
   "addSection": "Lisää osio",
   "selectAndCopy": "Valitse ja kopioi",


### PR DESCRIPTION
- When user has unsaved changes and tries to create new rubric or open a new rubric, show dialog that confirms if user wants to discard unsaved changes.